### PR TITLE
DM-18503: Support null values in dialog submission fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+0.3.1 (2019-03-15)
+==================
+
+The ``com.slack.dialog_submission_v1`` schema now permits the value from a field to be ``null``.
+This is true if a Slack dialog field is optional and the user does not set a value.
+
+:jirap:`DM-18503`
+
 0.3.0 (2019-02-21)
 ==================
 

--- a/kubernetes/sqrbot-jr-deployment.yaml
+++ b/kubernetes/sqrbot-jr-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: sqrbot-jr-app
-        image: lsstsqre/sqrbot-jr:0.3.0
+        image: lsstsqre/sqrbot-jr:tickets-DM-18503
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/kubernetes/sqrbot-jr-deployment.yaml
+++ b/kubernetes/sqrbot-jr-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: sqrbot-jr-app
-        image: lsstsqre/sqrbot-jr:tickets-DM-18503
+        image: lsstsqre/sqrbot-jr:0.3.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/sqrbot/schemas/interactions/dialog_submission.json
+++ b/sqrbot/schemas/interactions/dialog_submission.json
@@ -11,8 +11,8 @@
     },
     {
       "name": "submission",
-      "type": {"type": "map", "values": "string"},
-      "doc": "A hash of key/value pairs representing the user's submission. Each key is a name field your app provided when composing the form. Each value is the user's submitted value, or in the case of a static select menu, the value you assigned to a specific response. The selection from a dynamic menu, the value can be a channel ID, user ID, etc."
+      "type": {"type": "map", "values": ["null", "string"]},
+      "doc": "A hash of key/value pairs representing the user's submission. Each key is a name field your app provided when composing the form. Each value is the user's submitted value, or in the case of a static select menu, the value you assigned to a specific response. The selection from a dynamic menu, the value can be a channel ID, user ID, etc.. If the field is optional, and unset, the value is null."
     },
     {
       "name": "team",


### PR DESCRIPTION
If a field is optional, and the user doesn't set a value, than the result will be null. This change lets us accept those null values.