### PR TITLE
DM-19607: Add sqrbot-jr/retentionMinutes config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.4.0 (2019-05-03)
+==================
+
+There is a new configuration environment variable, ``SQRBOTJR_RETENTION_MINUTES``, which configures how long a Slack messages are retained in Kafka topics.
+The default is 30 minutes so that consumers can query recent history for context, but brokers will still not have too much data that could be potentially exposed.
+
 0.3.1 (2019-03-15)
 ==================
 

--- a/kubernetes/sqrbot-jr-deployment.yaml
+++ b/kubernetes/sqrbot-jr-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: sqrbot-jr-app
-        image: lsstsqre/sqrbot-jr:0.3.1
+        image: lsstsqre/sqrbot-jr:0.4.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/sqrbot/config.py
+++ b/sqrbot/config.py
@@ -60,4 +60,8 @@ def create_config():
     # Slack bot token
     c['sqrbot-jr/slackToken'] = os.getenv('SQRBOTJR_TOKEN')
 
+    # Kafka retention of Slack events in minutes
+    c['sqrbot-jr/retentionMinutes'] = \
+        os.getenv('SQRBOTJR_RETENTION_MINUTES', '30')
+
     return c

--- a/sqrbot/topics.py
+++ b/sqrbot/topics.py
@@ -189,10 +189,14 @@ def configure_topics(app):
                 partitions=len(topic.partitions),
                 replication_factor=len(partitions[0].replicas))
             continue
+        retention_ms = int(app['sqrbot-jr/retentionMinutes']) * 60000
         new_topics.append(NewTopic(
             topic_name,
             num_partitions=default_num_partitions,
-            replication_factor=default_replication_factor))
+            replication_factor=default_replication_factor,
+            config={
+                'retention.ms': str(retention_ms)
+            }))
 
     if len(new_topics) > 0:
         fs = client.create_topics(new_topics)


### PR DESCRIPTION
This configuration allows us to set the retention period in Kafka for Slack messages.